### PR TITLE
smallGceFix

### DIFF
--- a/src/main/java/com/hazelcast/jclouds/ComputeServiceBuilder.java
+++ b/src/main/java/com/hazelcast/jclouds/ComputeServiceBuilder.java
@@ -182,7 +182,7 @@ public class ComputeServiceBuilder {
             throw new UnsupportedOperationException("Both credential and credentialPath are set. Use only one method.");
         }
         if (credentialPath != null) {
-            credential = getCredentialFromFile(credential, credentialPath);
+            credential = getCredentialFromFile(cloudProvider, credentialPath);
         }
 
         if (LOGGER.isFinestEnabled()) {


### PR DESCRIPTION
When using hazelcast-jclouds on GCE you are supposed to provide credentialPath and not credential. If you provide both properties credentialPath and credential you will get an exception.

If credentialPath is set it will attempt to read the credential from the provided file path. 
But the first argument to method getCredentialFromFile() is credential, which in this scenario always is null. The first argument should obviously be "cloudProvider".

Thanks,
Håkan