### PR TITLE
Allow to configure custom endpoints for generic APIs and properly bridge jclouds logging to Hazelcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Property Name | Type | Description
 `provider`|String|String value that is used to identify ComputeService provider. For example, "google-compute-engine" is used for Google Cloud services. See the <a href="https://jclouds.apache.org/reference/providers/#compute " target="_blank">full provider list here</a>.
 `identity`|String|Cloud Provider identity, can be thought of as a user name for cloud services.
 `credential`|String|Cloud Provider credential, can be thought of as a password for cloud services.
+`endpoint`|String|Defines the endpoint for a gneric API such as OpenStack or CloudStack (optional).
 `zones`|String|Defines zone for a cloud service (optional). Can be used with comma separated values for multiple values.
 `regions`|String|Defines region for a cloud service (optional). Can be used with comma separated values for multiple values.
 `tag-keys`|String|Filters cloud instances with tags (optional). Can be used with comma separated values for multiple values.

--- a/src/main/java/com/hazelcast/jclouds/ComputeServiceBuilder.java
+++ b/src/main/java/com/hazelcast/jclouds/ComputeServiceBuilder.java
@@ -19,10 +19,12 @@ package com.hazelcast.jclouds;
 import com.google.common.base.Charsets;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.jclouds.logging.HazelcastLoggingModule;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.jclouds.Constants;
@@ -173,6 +175,7 @@ public class ComputeServiceBuilder {
      */
     ComputeService build() {
         final String cloudProvider = getOrNull(JCloudsProperties.PROVIDER);
+        final String endpoint = getOrNull(JCloudsProperties.ENDPOINT);
         final String identity = getOrNull(JCloudsProperties.IDENTITY);
         String credential = getOrNull(JCloudsProperties.CREDENTIAL);
         final String credentialPath = getOrNull(JCloudsProperties.CREDENTIAL_PATH);
@@ -191,12 +194,19 @@ public class ComputeServiceBuilder {
 
         final String roleName = getOrNull(JCloudsProperties.ROLE_NAME);
         ContextBuilder contextBuilder = newContextBuilder(cloudProvider, identity, credential, roleName);
+        if (endpoint != null) {
+            if (LOGGER.isFinestEnabled()) {
+                LOGGER.finest("Using custom endpoint: " + endpoint);
+            }
+            contextBuilder.endpoint(endpoint);
+        }
 
         Properties jcloudsProperties = buildRegionZonesConfig();
         buildTagConfig();
         buildNodeFilter();
 
         computeService = contextBuilder.overrides(jcloudsProperties)
+                .modules(ImmutableSet.of(new HazelcastLoggingModule()))
                 .buildView(ComputeServiceContext.class)
                 .getComputeService();
 

--- a/src/main/java/com/hazelcast/jclouds/JCloudsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/jclouds/JCloudsDiscoveryStrategyFactory.java
@@ -37,6 +37,7 @@ public class JCloudsDiscoveryStrategyFactory implements DiscoveryStrategyFactory
 
     static {
         List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
+        propertyDefinitions.add(JCloudsProperties.ENDPOINT);
         propertyDefinitions.add(JCloudsProperties.CREDENTIAL);
         propertyDefinitions.add(JCloudsProperties.CREDENTIAL_PATH);
         propertyDefinitions.add(JCloudsProperties.GROUP);

--- a/src/main/java/com/hazelcast/jclouds/JCloudsProperties.java
+++ b/src/main/java/com/hazelcast/jclouds/JCloudsProperties.java
@@ -46,6 +46,10 @@ public final class JCloudsProperties {
      */
     public static final PropertyDefinition CREDENTIAL = property("credential", STRING);
     /**
+     * Property used to define the endpoint for generic APIs such as OpenStack or CloudStack.
+     */
+    public static final PropertyDefinition ENDPOINT = property("endpoint", STRING);
+    /**
      * Property used to define zones for node filtering
      */
     public static final PropertyDefinition ZONES = property("zones", STRING);

--- a/src/main/java/com/hazelcast/jclouds/logging/HazelcastLogger.java
+++ b/src/main/java/com/hazelcast/jclouds/logging/HazelcastLogger.java
@@ -25,9 +25,11 @@ import com.hazelcast.logging.ILogger;
 /**
  * Bridges the jclouds logging framework to Hazelcast logging.
  */
-
 public class HazelcastLogger implements Logger {
 
+    /**
+     * Creates the jclouds logger that bridges messages to Hazelcast.
+     */
     public static class Factory implements LoggerFactory {
         public Logger getLogger(String category) {
             return new HazelcastLogger(category,

--- a/src/main/java/com/hazelcast/jclouds/logging/HazelcastLogger.java
+++ b/src/main/java/com/hazelcast/jclouds/logging/HazelcastLogger.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jclouds.logging;
+
+import java.util.logging.Level;
+
+import org.jclouds.logging.Logger;
+
+import com.hazelcast.logging.ILogger;
+
+/**
+ * Bridges the jclouds logging framework to Hazelcast logging.
+ */
+
+public class HazelcastLogger implements Logger {
+
+    public static class Factory implements LoggerFactory {
+        public Logger getLogger(String category) {
+            return new HazelcastLogger(category,
+                    com.hazelcast.logging.Logger.getLogger(category));
+        }
+    }
+
+    private final ILogger logger;
+    private final String category;
+
+    public HazelcastLogger(String category, ILogger logger) {
+        this.logger = logger;
+        this.category = category;
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public void trace(String message, Object... args) {
+        logger.finest(String.format(message, args));
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isFinestEnabled();
+    }
+
+    @Override
+    public void debug(String message, Object... args) {
+        logger.fine(String.format(message, args));
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isFineEnabled();
+    }
+
+    @Override
+    public void info(String message, Object... args) {
+        logger.info(String.format(message, args));
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isLoggable(Level.INFO);
+    }
+
+    @Override
+    public void warn(String message, Object... args) {
+        logger.warning(String.format(message, args));
+    }
+
+    @Override
+    public void warn(Throwable throwable, String message, Object... args) {
+        logger.warning(String.format(message, args), throwable);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isLoggable(Level.WARNING);
+    }
+
+    @Override
+    public void error(String message, Object... args) {
+        logger.severe(String.format(message, args));
+    }
+
+    @Override
+    public void error(Throwable throwable, String message, Object... args) {
+        logger.severe(String.format(message, args), throwable);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isLoggable(Level.SEVERE);
+    }
+
+}

--- a/src/main/java/com/hazelcast/jclouds/logging/HazelcastLoggingModule.java
+++ b/src/main/java/com/hazelcast/jclouds/logging/HazelcastLoggingModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jclouds.logging;
+
+import org.jclouds.logging.Logger.LoggerFactory;
+import org.jclouds.logging.config.LoggingModule;
+
+/**
+ * Guice module to configure the logging bridge between jclouds and Hazelcast.
+ */
+public class HazelcastLoggingModule extends LoggingModule {
+
+    @Override
+    public LoggerFactory createLoggerFactory() {
+        return new HazelcastLogger.Factory();
+    }
+
+}

--- a/src/main/java/com/hazelcast/jclouds/logging/package-info.java
+++ b/src/main/java/com/hazelcast/jclouds/logging/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes for bridging jclouds loggers to Hazelcast.
+ */
+package com.hazelcast.jclouds.logging;
+

--- a/src/test/java/com/hazelcast/jclouds/JCloudsDiscoveryFactoryTest.java
+++ b/src/test/java/com/hazelcast/jclouds/JCloudsDiscoveryFactoryTest.java
@@ -51,7 +51,7 @@ public class JCloudsDiscoveryFactoryTest extends HazelcastTestSupport {
 
         DiscoveryStrategyConfig providerConfig = discoveryConfig.getDiscoveryStrategyConfigs().iterator().next();
 
-        assertEquals(11, providerConfig.getProperties().size());
+        assertEquals(12, providerConfig.getProperties().size());
         assertEquals("aws-ec2", providerConfig.getProperties().get("provider"));
         assertEquals("test", providerConfig.getProperties().get("identity"));
         assertEquals("test", providerConfig.getProperties().get("credential"));
@@ -64,6 +64,7 @@ public class JCloudsDiscoveryFactoryTest extends HazelcastTestSupport {
         assertEquals("5702", providerConfig.getProperties().get("hz-port"));
         assertEquals("myfile.json", providerConfig.getProperties().get("credentialPath"));
         assertEquals("myRole", providerConfig.getProperties().get("role-name"));
+        assertEquals("http://foo/bar", providerConfig.getProperties().get("endpoint"));
     }
 
     @Test

--- a/src/test/resources/test-jclouds-config.xml
+++ b/src/test/resources/test-jclouds-config.xml
@@ -42,6 +42,7 @@
                         <property name="hz-port">5702</property>
                         <property name="credentialPath">myfile.json</property>
                         <property name="role-name">myRole</property>
+                        <property name="endpoint">http://foo/bar</property>
                     </properties>
                 </discovery-strategy>
             </discovery-strategies>


### PR DESCRIPTION
In jclouds, generic APIs such as OpenStack or CloudStack require the endpoint parameter to be configured when creating the context. This PR adds the corresponding property so it can be configured.

It also adds a proper logging module so all jclouds logs can be bridged to the Hazelcast logger, so all internal jclouds logs can be properly configured from Hazelcast too.

/cc @ericjturley