### PR TITLE
Fix Request URL of credential Api

### DIFF
--- a/src/main/java/com/hazelcast/jclouds/IAMRoleCredentialSupplierBuilder.java
+++ b/src/main/java/com/hazelcast/jclouds/IAMRoleCredentialSupplierBuilder.java
@@ -39,7 +39,7 @@ public class IAMRoleCredentialSupplierBuilder {
     private static final String IAM_ROLE_ENDPOINT = "169.254.169.254";
     private String roleName;
     private SessionCredentials credentials;
-    private String query = "latest/meta-data/iam/security-credentials/";
+    private String query = "/latest/meta-data/iam/security-credentials/";
 
     public IAMRoleCredentialSupplierBuilder() {
     }


### PR DESCRIPTION
Without a forward slash before the path, it is not valid path per the HTTP RFC, and causes recent version of AWS VMs returning a 404 not found error.